### PR TITLE
Add implementation of did:ebsi method.

### DIFF
--- a/packages/did-core-test-server/suites/did-consumption/default.js
+++ b/packages/did-core-test-server/suites/did-consumption/default.js
@@ -36,6 +36,7 @@ module.exports = {
     require('../implementations/did-onion-spruce.json'),
     require('../implementations/did-pkh-spruce.json'),
     require('../implementations/did-webkey-spruce.json'),
+    require('../implementations/did-ebsi.json'),
     ...brokenFixtures
   ]
 };

--- a/packages/did-core-test-server/suites/did-core-properties/default.js
+++ b/packages/did-core-test-server/suites/did-core-properties/default.js
@@ -35,6 +35,7 @@ module.exports = {
     require('../implementations/did-onion-spruce.json'),
     require('../implementations/did-pkh-spruce.json'),
     require('../implementations/did-webkey-spruce.json'),
+    require('../implementations/did-ebsi.json'),
     ...brokenFixtures
 
   ],

--- a/packages/did-core-test-server/suites/did-identifier/default.js
+++ b/packages/did-core-test-server/suites/did-identifier/default.js
@@ -37,6 +37,7 @@ module.exports = {
     require('../implementations/did-onion-spruce.json'),
     require('../implementations/did-pkh-spruce.json'),
     require('../implementations/did-webkey-spruce.json'),
+    require('../implementations/did-ebsi.json'),
    ...brokenFixtures
   ],
 };

--- a/packages/did-core-test-server/suites/did-production/default.js
+++ b/packages/did-core-test-server/suites/did-production/default.js
@@ -36,6 +36,7 @@ module.exports = {
     require('../implementations/did-onion-spruce.json'),
     require('../implementations/did-pkh-spruce.json'),
     require('../implementations/did-webkey-spruce.json'),
+    require('../implementations/did-ebsi.json'),
     ...brokenFixtures
   ],
 };

--- a/packages/did-core-test-server/suites/implementations/did-ebsi.json
+++ b/packages/did-core-test-server/suites/implementations/did-ebsi.json
@@ -1,0 +1,52 @@
+{
+  "didMethod": "did:ebsi",
+  "implementation": "EBSI libraries and APIs",
+  "implementer": "EBSI",
+  "supportedContentTypes": [
+    "application/did+ld+json"
+  ],
+  "dids": [
+    "did:ebsi:4RPpNqqGv6NtrMMuPStGUJQ4zgCmUn5ZNqcxmkmdpWbd"
+  ],
+  "didParameters": {},
+  "did:ebsi:4RPpNqqGv6NtrMMuPStGUJQ4zgCmUn5ZNqcxmkmdpWbd": {
+    "didDocumentDataModel": {
+      "properties": {
+        "alsoKnownAs": [
+          "https://danubetech.com/"
+        ],
+        "authentication": [
+          "did:ebsi:4RPpNqqGv6NtrMMuPStGUJQ4zgCmUn5ZNqcxmkmdpWbd#keys-1"
+        ],
+        "service": [],
+        "id": "did:ebsi:4RPpNqqGv6NtrMMuPStGUJQ4zgCmUn5ZNqcxmkmdpWbd",
+        "verificationMethod": [{
+          "id": "did:ebsi:4RPpNqqGv6NtrMMuPStGUJQ4zgCmUn5ZNqcxmkmdpWbd#keys-1",
+          "type": "Secp256k1VerificationKey2018",
+          "controller": "did:ebsi:4RPpNqqGv6NtrMMuPStGUJQ4zgCmUn5ZNqcxmkmdpWbd",
+          "publicKeyJwk": {
+            "kty": "EC",
+            "crv": "secp256k1",
+            "x": "SweGUiB0HA5C07fX2TnpGa64nm4AjgoCxC3OjxG10nc",
+            "y": "UGs0kqk1Gr1suiZqUPqDNB_-nlq4Lc-0heYJRKATJDE"
+          }
+        }],
+        "assertionMethod": [
+          "did:ebsi:4RPpNqqGv6NtrMMuPStGUJQ4zgCmUn5ZNqcxmkmdpWbd#keys-1"
+        ]
+      }
+    },
+    "application/did+ld+json": {
+      "didDocumentDataModel": {
+        "representationSpecificEntries": {
+          "@context": "https://www.w3.org/ns/did/v1"
+        }
+      },
+      "representation": "{ \"@context\": \"https://www.w3.org/ns/did/v1\", \"alsoKnownAs\": [ \"https://danubetech.com/\" ], \"authentication\": [ \"did:ebsi:4RPpNqqGv6NtrMMuPStGUJQ4zgCmUn5ZNqcxmkmdpWbd#keys-1\" ], \"service\": [], \"id\": \"did:ebsi:4RPpNqqGv6NtrMMuPStGUJQ4zgCmUn5ZNqcxmkmdpWbd\", \"verificationMethod\": [ { \"id\": \"did:ebsi:4RPpNqqGv6NtrMMuPStGUJQ4zgCmUn5ZNqcxmkmdpWbd#keys-1\", \"type\": \"Secp256k1VerificationKey2018\", \"controller\": \"did:ebsi:4RPpNqqGv6NtrMMuPStGUJQ4zgCmUn5ZNqcxmkmdpWbd\", \"publicKeyJwk\": { \"kty\": \"EC\", \"crv\": \"secp256k1\", \"x\": \"SweGUiB0HA5C07fX2TnpGa64nm4AjgoCxC3OjxG10nc\", \"y\": \"UGs0kqk1Gr1suiZqUPqDNB_-nlq4Lc-0heYJRKATJDE\" } } ], \"assertionMethod\": [ \"did:ebsi:4RPpNqqGv6NtrMMuPStGUJQ4zgCmUn5ZNqcxmkmdpWbd#keys-1\" ] }",
+      "didDocumentMetadata": {},
+      "didResolutionMetadata": {
+        "contentType": "application/did+ld+json"
+      }
+    }
+  }
+}


### PR DESCRIPTION
This adds an implementation report for did:ebsi. It was generated using libraries and APIs from the EBSI Early Adopter program. 

Generating this report did NOT use any parts of the DIF Universal Resolver (even though that also supports did:ebsi).